### PR TITLE
Increase gross income exclusion from $200 to $5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ SEC. 201. GAIN FROM DISPOSITION OF DIGITAL ASSETS.
 
 "(b) Limitation.—
 
-"(1) In general.—The amount of gain or loss excluded from gross income under subsection (a) with respect to a sale or exchange shall not exceed $200.
+"(1) In general.—The amount of gain or loss excluded from gross income under subsection (a) with respect to a sale or exchange shall not exceed $5,000.
 
 "(2) Aggregation rule.—For purposes of this subsection, all sales or exchanges which are part of the same transaction (or a series of related transactions) shall be treated as one sale or exchange.
 


### PR DESCRIPTION
The $200 exclusion from gross income is too small. The exclusion amount should be increased to at least $5,000. People routinely spend more than $200 every time they go to the grocery store. Medical bills are typically over $200. Some households spend over $200 on their monthly electric bill and cellphone bill. People are now paying $100-$200 to fill up their gas tank. Inflation has already made the proposed $200 exclusion limit obsolete. For example, it should be possible for someone to make a monthly car payment or pay their monthly mortgage bill with cryptocurrency without paying taxes. The exclusion limit must be increased to allow common daily/weekly/monthly expenses to be paid without incurring taxes and the associated record-keeping. This higher exclusion limit of $5,000 will allow cryptocurrencies (e.g., Bitcoin via the Lightning Network) to be used as a medium of exchange in the United States, which is important for upgrading our slow, expensive, and outdated legacy financial system.