### PR TITLE
delete "customer agreement" req. on "protocols"

### DIFF
--- a/RFIA
+++ b/RFIA
@@ -1552,7 +1552,7 @@ Chapter 98 of title 31, United States Code, as added by section 101(a) of this A
 
 "9802. Consumer protection standards for digital assets
 
-"(a) In General.—A person or protocol that provides digital asset services shall ensure that the scope of permissible transactions that may be undertaken with customer digital assets is disclosed clearly in a customer agreement.
+"(a) In General.—A person that provides digital asset services shall ensure that the scope of permissible transactions that may be undertaken with customer digital assets is disclosed clearly in a customer agreement.
 
 "(b) Notice.—A person who provides digital asset services shall provide clear notice to each customer, and require acknowledgment, of the following:
 


### PR DESCRIPTION
as part of the consumer protection section, deletes the requirement that "protocols" enter into an agreement with customers--which is impossible, because protocols are just code